### PR TITLE
If a hash is the last argument on a method call, no braces are needed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Generated migration file
 ```ruby
 class CreateWorkerNames < ActiveRecord::Migration
   def change
-    create_table :worker_names, {id: false, options: "ENGINE=QUEUE"} do |t|
+    create_table :worker_names, id: false, options: "ENGINE=QUEUE" do |t|
       t.string :job_id, null: false
       t.string :title
       t.datetime :enqueued_at, null: false

--- a/lib/generators/shinq/worker/templates/create_table_migration.erb
+++ b/lib/generators/shinq/worker/templates/create_table_migration.erb
@@ -1,6 +1,6 @@
 class <%= migration_class_name %> < ActiveRecord::Migration
   def change
-    create_table :<%= table_name %>, {id: false, options: "ENGINE=QUEUE"} do |t|
+    create_table :<%= table_name %>, id: false, options: "ENGINE=QUEUE" do |t|
       t.string :job_id, null: false
 <% attributes.each do |attribute| -%>
       t.<%= attribute.type %> :<%= attribute.name %><%= attribute.inject_options %>


### PR DESCRIPTION
We usually omit braces If a hash is the last argument on a method call.

http://docs.ruby-lang.org/en/2.1.0/Hash.html#class-Hash-label-Common+Uses
