### PR TITLE
Enable to use gem mysql2 0.4.x

### DIFF
--- a/shinq.gemspec
+++ b/shinq.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec-mocks"
   spec.add_development_dependency "simplecov"
 
-  spec.add_dependency "mysql2", "~> 0.3.16"
+  spec.add_dependency "mysql2", ">= 0.3.16", "< 0.5"
   spec.add_dependency "sql-maker", "~> 0.0.4"
   spec.add_dependency "activesupport", "~> 4.2.0"
   spec.add_dependency "activejob", "~> 4.2.0"


### PR DESCRIPTION
Hi,

As far as I run tests at my Mac OSX PC with ruby v2.3.1 and latest mysql2 v0.4.5, there seems to be no problem.
If you accept this patch, I will be happier.

Thanks,
