### PR TITLE
Add new config option '--[no-]abort-on-error' to change behavior to proceed queue

### DIFF
--- a/lib/shinq/cli.rb
+++ b/lib/shinq/cli.rb
@@ -63,6 +63,10 @@ module Shinq
           opts[:statistics] = v.to_i
         end
 
+        opt.on('--[no-]abort-on-error', 'Abort ') do |v|
+          opts[:abort_on_error] = v
+        end
+
         opt.on('-v', '--version', 'Print version') do |v|
           puts "Shinq #{Shinq::VERSION}"
           exit(0)

--- a/lib/shinq/configuration.rb
+++ b/lib/shinq/configuration.rb
@@ -1,18 +1,27 @@
 module Shinq
   class ConfigurationError < StandardError; end
 
+  # @!attribute abort_on_error
+  #   @return [Boolean] Whether do +queue_abort()+ on performing failure.
+  #   @see Shinq::Launcher#run
+  #
+  #   Defaults to +true+, which means that worker do +queue_end()+ AFTER it proceeds a job.
+  #   If it is +false+, worker do +queue_end()+ BEFORE it proceeds a job.
+  #   You may need to set it +false+ for jobs which take very long time to proceed.
+  #   You may also need to handle performing error manually then.
   class Configuration
-    attr_accessor :require, :worker_name, :db_config, :queue_db, :default_db, :process, :queue_timeout, :daemonize, :statistics, :lifecycle
+    attr_accessor :require, :worker_name, :db_config, :queue_db, :default_db, :process, :queue_timeout, :daemonize, :statistics, :lifecycle, :abort_on_error
 
     DEFAULT = {
       require: '.',
       process: 1,
       queue_timeout: 1,
-      daemonize: false
+      daemonize: false,
+      abort_on_error: true
     }
 
     def initialize(opts)
-      %i(require worker_name db_config queue_db default_db process queue_timeout daemonize statistics lifecycle).each do |k|
+      %i(require worker_name db_config queue_db default_db process queue_timeout daemonize statistics lifecycle abort_on_error).each do |k|
         send(:"#{k}=", opts[k] || DEFAULT[k])
       end
     end

--- a/spec/shinq/configuration_spec.rb
+++ b/spec/shinq/configuration_spec.rb
@@ -15,6 +15,7 @@ describe Shinq::Configuration do
     it { is_expected.to respond_to(:daemonize) }
     it { is_expected.to respond_to(:statistics) }
     it { is_expected.to respond_to(:lifecycle) }
+    it { is_expected.to respond_to(:abort_on_error) }
   end
 
   describe ".new" do


### PR DESCRIPTION
Hello,

I want to add a config in the title to solve a problem.
I think there will be another solution. This is just a proposal.

### TL;DR

After this change, ...

* One can start a worker with `--no-abort-on-error`.
* With this option, the worker does `queue_end()` immedeatly after fetching a queue.

### Problem

Sometimes I need to use q4m for jobs which take long time -- from 10 minutes to a few hours.
In such cases, MySQL server goes away during worker's `#perform` procedure.
I have extended `wait_timeout` parameter of MySQL server for workaround. Or I can send `ping` to MySQL server during `#perform` procedure.

But holding a queue such long time is unsafe and not preffered, I think.

Then I add this config option.

----

I will be happy if you take a look to this PR and if you give a feedback for this.

And if you'd like a casual communication, talk to [@key_amb on twitter](https://twitter.com/key_amb). Japanese is OK.

Thanks,
