### PR TITLE
Raise Exception before running ServerEngine

### DIFF
--- a/lib/shinq/cli.rb
+++ b/lib/shinq/cli.rb
@@ -6,6 +6,7 @@ require 'shinq/statistics'
 require 'shinq/configuration'
 require 'shinq/logger'
 require 'serverengine'
+require 'active_support/inflector'
 
 module Shinq
   class OptionParseError < StandardError; end
@@ -30,7 +31,10 @@ module Shinq
         end
 
         opt.on('-w', '--worker value', 'Name of worker class') do |v|
+          worker_class = v.camelize.safe_constantize
+          raise OptionParseError, "worker class #{v.camelize} corresponding to #{v} does not exist" unless worker_class
           opts[:worker_name] = v
+          opts[:worker_class] = worker_class
         end
 
         opt.on('-p', '--process VALUE', 'Number of workers') do |v|

--- a/lib/shinq/configuration.rb
+++ b/lib/shinq/configuration.rb
@@ -10,7 +10,7 @@ module Shinq
   #   You may need to set it +false+ for jobs which take very long time to proceed.
   #   You may also need to handle performing error manually then.
   class Configuration
-    attr_accessor :require, :worker_name, :db_config, :queue_db, :default_db, :process, :queue_timeout, :daemonize, :statistics, :lifecycle, :abort_on_error
+    attr_accessor :require, :worker_name, :worker_class, :db_config, :queue_db, :default_db, :process, :queue_timeout, :daemonize, :statistics, :lifecycle, :abort_on_error
 
     DEFAULT = {
       require: '.',

--- a/lib/shinq/launcher.rb
+++ b/lib/shinq/launcher.rb
@@ -7,7 +7,7 @@ module Shinq
     # @see Shinq::Configuration#abort_on_error
     def run
       worker_name = Shinq.configuration.worker_name
-      worker_class = worker_name.camelize.constantize
+      worker_class = Shinq.configuration.worker_class
 
       @loop_count = 0
 


### PR DESCRIPTION
I would like to intentionally raise Exception in Shinq::CLI when worker class corresponding to specified worker name does not exist.

This patch will prevent infinite loop invoked by `worker_name.camelize.constantize` in Shinq::Launcher.