### PR TITLE
Make `value` consistent with upper-case `VALUE`

### DIFF
--- a/lib/shinq/cli.rb
+++ b/lib/shinq/cli.rb
@@ -30,7 +30,7 @@ module Shinq
           opts[:daemonize] = v
         end
 
-        opt.on('-w', '--worker value', 'Name of worker class') do |v|
+        opt.on('-w', '--worker VALUE', 'Name of worker class') do |v|
           worker_class = v.camelize.safe_constantize
           raise OptionParseError, "worker class #{v.camelize} corresponding to #{v} does not exist" unless worker_class
           opts[:worker_name] = v


### PR DESCRIPTION
If this is not intended, I would like to make help message consistent by upper-case `VALUE`.