### PR TITLE
Add --graceful-kill-timeout option

### DIFF
--- a/lib/shinq/cli.rb
+++ b/lib/shinq/cli.rb
@@ -41,6 +41,10 @@ module Shinq
           opts[:process] = v.to_i
         end
 
+        opt.on('--graceful-kill-timeout VALUE', 'Seconds to SIGQUIT workers even during performing jobs') do |v|
+          opts[:graceful_kill_timeout] = v.to_i
+        end
+
         opt.on('--queue-timeout VALUE', 'Waiting queue time(sec). use function of queue_wait(Q4M)') do |v|
           opts[:queue_timeout] = v.to_i
         end
@@ -108,6 +112,7 @@ module Shinq
         worker_type: 'process',
         pid_file: 'shinq.pid',
         workers: options.process,
+        worker_graceful_kill_timeout: options.graceful_kill_timeout
         logger: options.daemonize ? Shinq.logger : nil
       })
 

--- a/lib/shinq/configuration.rb
+++ b/lib/shinq/configuration.rb
@@ -10,11 +10,12 @@ module Shinq
   #   You may need to set it +false+ for jobs which take very long time to proceed.
   #   You may also need to handle performing error manually then.
   class Configuration
-    attr_accessor :require, :worker_name, :worker_class, :db_config, :queue_db, :default_db, :process, :queue_timeout, :daemonize, :statistics, :lifecycle, :abort_on_error
+    attr_accessor :require, :worker_name, :worker_class, :db_config, :queue_db, :default_db, :process, :graceful_kill_timeout, :queue_timeout, :daemonize, :statistics, :lifecycle, :abort_on_error
 
     DEFAULT = {
       require: '.',
       process: 1,
+      graceful_kill_timeout: 600,
       queue_timeout: 1,
       daemonize: false,
       abort_on_error: true

--- a/spec/shinq/configuration_spec.rb
+++ b/spec/shinq/configuration_spec.rb
@@ -11,6 +11,7 @@ describe Shinq::Configuration do
     it { is_expected.to respond_to(:queue_db) }
     it { is_expected.to respond_to(:default_db) }
     it { is_expected.to respond_to(:process) }
+    it { is_expected.to respond_to(:graceful_kill_timeout) }
     it { is_expected.to respond_to(:queue_timeout) }
     it { is_expected.to respond_to(:daemonize) }
     it { is_expected.to respond_to(:statistics) }


### PR DESCRIPTION
Hi 🐱 

I would like to add `--worker-graceful-timeout` option to Shinq.

With current version, when killing workers during tasks taking more than 600 seconds, workers are not gracefully killed but instantly killed with SIGQUIT by [serverengine](https://github.com/treasure-data/serverengine). This can lead to unintentional unsuccessful jobs.

I would like to fix this problem by introducing `--worker-graceful-timeout`. Those who need and tolerate long processing time can utilize this option.