### PR TITLE
Fix deprecation on SimpleCov

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,9 +3,9 @@ require 'simplecov'
 require 'yaml'
 require 'active_support/core_ext/hash'
 
-SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
+SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new(
   SimpleCov::Formatter::HTMLFormatter
-]
+)
 
 SimpleCov.start do
   add_filter 'spec'


### PR DESCRIPTION
Hi again 🐱 

I would like to fix following deprecation on SimpleCov.

` [DEPRECATION] ::[] is deprecated. Use ::new instead.`

You can see this warning also in travis raw log.