### PR TITLE
Add recent versions of Ruby on travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ rvm:
   - 2.2.0
   - 2.2.1
   - 2.2.2
+  - 2.2.7
+  - 2.3.4
+  - 2.4.1
 gemfile:
   - Gemfile
 before_install:


### PR DESCRIPTION
Hi. 🐱 

I've just added recent versions of Ruby on travis.yml.

If it is good to remove old minor Ruby versions (2.2.2, 2.2.1, and 2.2.0), I will remove them before merging this patch.