### PR TITLE
Fix bug on parsing options

### DIFF
--- a/lib/shinq/cli.rb
+++ b/lib/shinq/cli.rb
@@ -15,6 +15,7 @@ module Shinq
     def initialize(args=ARGV)
       setup_option(args)
       bootstrap
+      initialize_shinq
     end
 
     def setup_option(args)
@@ -31,10 +32,7 @@ module Shinq
         end
 
         opt.on('-w', '--worker VALUE', 'Name of worker class') do |v|
-          worker_class = v.camelize.safe_constantize
-          raise OptionParseError, "worker class #{v.camelize} corresponding to #{v} does not exist" unless worker_class
           opts[:worker_name] = v
-          opts[:worker_class] = worker_class
         end
 
         opt.on('-p', '--process VALUE', 'Number of workers') do |v|
@@ -102,6 +100,10 @@ module Shinq
       else
         require target
       end
+    end
+
+    def initialize_shinq
+      Shinq.configuration.constantize_worker_class
     end
 
     def run

--- a/lib/shinq/cli.rb
+++ b/lib/shinq/cli.rb
@@ -103,7 +103,7 @@ module Shinq
     end
 
     def initialize_shinq
-      Shinq.configuration.constantize_worker_class
+      Shinq.configuration.worker_class # check if worker_class is constantizable before running ServerEngine
     end
 
     def run

--- a/lib/shinq/configuration.rb
+++ b/lib/shinq/configuration.rb
@@ -10,7 +10,7 @@ module Shinq
   #   You may need to set it +false+ for jobs which take very long time to proceed.
   #   You may also need to handle performing error manually then.
   class Configuration
-    attr_accessor :require, :worker_name, :worker_class, :db_config, :queue_db, :default_db, :process, :graceful_kill_timeout, :queue_timeout, :daemonize, :statistics, :lifecycle, :abort_on_error
+    attr_accessor :require, :worker_name, :db_config, :queue_db, :default_db, :process, :graceful_kill_timeout, :queue_timeout, :daemonize, :statistics, :lifecycle, :abort_on_error
 
     DEFAULT = {
       require: '.',
@@ -25,6 +25,14 @@ module Shinq
       %i(require worker_name db_config queue_db default_db process queue_timeout daemonize statistics lifecycle abort_on_error).each do |k|
         send(:"#{k}=", opts[k] || DEFAULT[k])
       end
+    end
+
+    def constantize_worker_class
+      worker_class = worker_name.camelize.safe_constantize
+      unless worker_class
+        raise ConfigurationError, "worker class #{worker_name.camelize} corresponding to #{worker_name} does not exist"
+      end
+      worker_class
     end
 
     def default_db_config

--- a/lib/shinq/configuration.rb
+++ b/lib/shinq/configuration.rb
@@ -27,7 +27,7 @@ module Shinq
       end
     end
 
-    def constantize_worker_class
+    def worker_class
       worker_class = worker_name.camelize.safe_constantize
       unless worker_class
         raise ConfigurationError, "worker class #{worker_name.camelize} corresponding to #{worker_name} does not exist"

--- a/lib/shinq/launcher.rb
+++ b/lib/shinq/launcher.rb
@@ -7,7 +7,7 @@ module Shinq
     # @see Shinq::Configuration#abort_on_error
     def run
       worker_name = Shinq.configuration.worker_name
-      worker_class = Shinq.configuration.worker_class
+      worker_class = Shinq.configuration.constantize_worker_class
 
       @loop_count = 0
 

--- a/lib/shinq/launcher.rb
+++ b/lib/shinq/launcher.rb
@@ -7,7 +7,7 @@ module Shinq
     # @see Shinq::Configuration#abort_on_error
     def run
       worker_name = Shinq.configuration.worker_name
-      worker_class = Shinq.configuration.constantize_worker_class
+      worker_class = Shinq.configuration.worker_class
 
       @loop_count = 0
 

--- a/spec/helpers/my_worker.rb
+++ b/spec/helpers/my_worker.rb
@@ -1,0 +1,4 @@
+require 'active_job'
+class MyWorker < ActiveJob::Base
+  queue_as :my_workers
+end

--- a/spec/shinq/cli_spec.rb
+++ b/spec/shinq/cli_spec.rb
@@ -3,8 +3,16 @@ require 'shinq/cli'
 
 describe Shinq::CLI do
   describe '.new' do
-    context 'when there are no arguments' do
-      it { expect { Shinq::CLI.new(%w(--require shinq/cli)) }.not_to raise_error }
+    context 'when there are require statement' do
+      it 'requires and run the code' do
+        # NOTE: As CLI alters global process irreversibly, we only check the result
+        Shinq::CLI.new(%W[
+          --require my_worker
+          --db-config #{File.expand_path('../config/database.yml', __dir__)}
+          --worker my_worker
+        ])
+        expect(defined? MyWorker).to eq 'constant'
+      end
     end
   end
 
@@ -13,8 +21,14 @@ describe Shinq::CLI do
       allow_any_instance_of(ServerEngine::Daemon).to receive(:run).and_return(nil)
     end
 
-    it 'launches Shinq::Launcher' do
-      Shinq::CLI.new(%w(--require shinq/cli)).run
+    it 'launches Shinq::Launcher backended by ServerEngine' do
+      expect {
+        Shinq::CLI.new(%W[
+          --require my_worker
+          --db-config #{File.expand_path('../config/database.yml', __dir__)}
+          --worker my_worker
+        ]).run
+      }.not_to raise_error
     end
   end
 end

--- a/spec/shinq/configuration_spec.rb
+++ b/spec/shinq/configuration_spec.rb
@@ -33,18 +33,18 @@ describe Shinq::Configuration do
     end
   end
 
-  describe '#constantize_worker_class' do
+  describe '#worker_class' do
     context 'when worker_name is valid' do
       let(:configuration) { Shinq::Configuration.new(worker_name: 'shinq') }
       it 'constantizes worker_name to corresponding constant' do
-        expect(configuration.constantize_worker_class).to eq Shinq
+        expect(configuration.worker_class).to eq Shinq
       end
     end
 
     context 'when worker_name is invalid' do
       let(:configuration) { Shinq::Configuration.new(worker_name: 'invalid_shinq') }
 
-      it {expect { configuration.constantize_worker_class }.to raise_error(Shinq::ConfigurationError)}
+      it {expect { configuration.worker_class }.to raise_error(Shinq::ConfigurationError)}
     end
   end
 

--- a/spec/shinq/configuration_spec.rb
+++ b/spec/shinq/configuration_spec.rb
@@ -33,6 +33,21 @@ describe Shinq::Configuration do
     end
   end
 
+  describe '#constantize_worker_class' do
+    context 'when worker_name is valid' do
+      let(:configuration) { Shinq::Configuration.new(worker_name: 'shinq') }
+      it 'constantizes worker_name to corresponding constant' do
+        expect(configuration.constantize_worker_class).to eq Shinq
+      end
+    end
+
+    context 'when worker_name is invalid' do
+      let(:configuration) { Shinq::Configuration.new(worker_name: 'invalid_shinq') }
+
+      it {expect { configuration.constantize_worker_class }.to raise_error(Shinq::ConfigurationError)}
+    end
+  end
+
   describe "#default_db_config" do
     context "when default_db is present" do
       let(:configuration) { Shinq::Configuration.new({}) }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,11 @@
+ENV['RAILS_ENV'] ||= 'test'
+$LOAD_PATH << File.expand_path('../helpers', __FILE__)
+
 require 'rspec/mocks/standalone'
 require 'simplecov'
 require 'yaml'
 require 'active_support/core_ext/hash'
+require 'mysql2'
 
 def load_database_config
   db_config = YAML.load_file(File.expand_path('./config/database.yml', __dir__)).symbolize_keys


### PR DESCRIPTION
@ryopeko 

I am very sorry that I have left another bug in my PR #6.

Because String#constantize was invoked before requiring `rails` or
user-specified ruby code, the 'String#constantize' failed.

This patch can fix the bug.
Also, in order to prevent another bug, I have improved the test on CLI.