### PR TITLE
Add Delayed functionality to shinq

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ class CreateWorkerNames < ActiveRecord::Migration
     create_table :worker_names, id: false, options: "ENGINE=QUEUE" do |t|
       t.string :job_id, null: false
       t.string :title
+      t.integer :scheduled_at, limit: 8, default: 0, null: false
       t.datetime :enqueued_at, null: false
     end
   end
@@ -78,6 +79,7 @@ mysql> show create table worker_names\G
 Create Table: CREATE TABLE `worker_names` (
   `job_id` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
   `title` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `scheduled_at` bigint(20) NOT NULL DEFAULT '0',
   `enqueued_at` datetime NOT NULL
 ) ENGINE=QUEUE DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci
 ```

--- a/lib/generators/shinq/worker/templates/create_table_migration.erb
+++ b/lib/generators/shinq/worker/templates/create_table_migration.erb
@@ -5,6 +5,7 @@ class <%= migration_class_name %> < ActiveRecord::Migration
 <% attributes.each do |attribute| -%>
       t.<%= attribute.type %> :<%= attribute.name %><%= attribute.inject_options %>
 <% end -%>
+      t.integer :scheduled_at, limit: 8, default: 0, null: false
       t.datetime :enqueued_at, null: false
     end
   end

--- a/lib/shinq.rb
+++ b/lib/shinq.rb
@@ -32,6 +32,14 @@ module Shinq
     @connections[db_name] ||= setup_db_connection(db_name)
   end
 
+  def self.clear_all_connections!
+    return unless @connections
+    @connections.each do |_db_name, connection|
+      connection && connection.close
+    end
+    @connections = {}
+  end
+
   def self.logger
     @logger
   end

--- a/lib/shinq.rb
+++ b/lib/shinq.rb
@@ -24,12 +24,12 @@ module Shinq
 
   def self.setup_db_connection(db_name)
     raise Shinq::ConfigurationError unless self.configuration.db_defined?(db_name)
-    @connections[db_name] = Mysql2::Client.new(self.configuration.db_config[db_name])
+    @connections[db_name.to_sym] = Mysql2::Client.new(self.configuration.db_config[db_name])
   end
 
   def self.connection(db_name: self.default_db)
     @connections ||= {}
-    @connections[db_name] ||= setup_db_connection(db_name)
+    @connections[db_name.to_sym] ||= setup_db_connection(db_name)
   end
 
   def self.clear_all_connections!

--- a/lib/shinq/active_job/queue_adapters/shinq_adapter.rb
+++ b/lib/shinq/active_job/queue_adapters/shinq_adapter.rb
@@ -9,6 +9,15 @@ module ActiveJob
             args: job.arguments.first
           )
         end
+
+        def enqueue_at(job, timestamp)
+          Shinq::Client.enqueue(
+            table_name: job.queue_name,
+            job_id: job.job_id,
+            args: job.arguments.first,
+            scheduled_at: timestamp,
+          )
+        end
       end
     end
   end

--- a/lib/shinq/cli.rb
+++ b/lib/shinq/cli.rb
@@ -103,6 +103,7 @@ module Shinq
     end
 
     def initialize_shinq
+      Shinq::Client.fetch_column_names(table_name: Shinq.configuration.worker_name.pluralize)
       Shinq.configuration.worker_class # check if worker_class is constantizable before running ServerEngine
     end
 

--- a/lib/shinq/client.rb
+++ b/lib/shinq/client.rb
@@ -28,7 +28,7 @@ module Shinq
     end
 
     def self.dequeue(table_name:)
-      condition = schedulable?(table_name: table_name) ? ":scheduled_at<#{Time.now.to_i}" : ''
+      condition = schedulable?(table_name: table_name) ? ":scheduled_at<=#{Time.now.to_i}" : ''
       quoted = SQL::Maker::Quoting.quote("#{table_name}#{condition}")
 
       queue_timeout_quoted = SQL::Maker::Quoting.quote(Shinq.configuration.queue_timeout)

--- a/lib/shinq/client.rb
+++ b/lib/shinq/client.rb
@@ -66,7 +66,7 @@ module Shinq
 
     def self.column_names(table_name:)
       @column_names_by_table_name ||= {}
-      @column_names_by_table_name[table_name] ||= begin
+      @column_names_by_table_name[table_name.to_sym] ||= begin
         quoted = SQL::Maker::Quoting.quote(table_name)
         column = Shinq.connection.query(<<-EOS).map { |record| record['column_name'] }
 select column_name from information_schema.columns where table_schema = database() and table_name = #{quoted}
@@ -76,7 +76,7 @@ select column_name from information_schema.columns where table_schema = database
 
     def self.fetch_column_names(table_name:)
       @column_names_by_table_name ||= {}
-      @column_names_by_table_name.delete(table_name)
+      @column_names_by_table_name.delete(table_name.to_sym)
       column_names(table_name: table_name)
     end
 

--- a/lib/shinq/launcher.rb
+++ b/lib/shinq/launcher.rb
@@ -3,6 +3,10 @@ require 'active_support/inflector'
 
 module Shinq
   module Launcher
+    def initialize
+      Shinq.clear_all_connections!
+    end
+
     # Wait configured queue and proceed each of them until stop.
     # @see Shinq::Configuration#abort_on_error
     def run

--- a/shinq.gemspec
+++ b/shinq.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "rspec-mocks"
   spec.add_development_dependency "simplecov"
+  spec.add_development_dependency "timecop"
 
   spec.add_dependency "mysql2", ">= 0.3.16", "< 0.5"
   spec.add_dependency "sql-maker", "~> 0.0.4"

--- a/spec/db/structure.sql
+++ b/spec/db/structure.sql
@@ -5,3 +5,11 @@ CREATE TABLE `queue_test` (
   `scheduled_at` bigint(20) NOT NULL DEFAULT '0',
   `enqueued_at` datetime NOT NULL
 ) ENGINE=QUEUE;
+
+DROP TABLE IF EXISTS `queue_test_without_scheduled_at`;
+
+CREATE TABLE `queue_test_without_scheduled_at` (
+  `job_id` varchar(255) NOT NULL,
+  `title` varchar(255),
+  `enqueued_at` datetime NOT NULL
+) ENGINE=QUEUE;

--- a/spec/db/structure.sql
+++ b/spec/db/structure.sql
@@ -2,5 +2,6 @@ DROP TABLE IF EXISTS `queue_test`;
 CREATE TABLE `queue_test` (
   `job_id` varchar(255) NOT NULL,
   `title` varchar(255),
+  `scheduled_at` bigint(20) NOT NULL DEFAULT '0',
   `enqueued_at` datetime NOT NULL
 ) ENGINE=QUEUE;

--- a/spec/db/structure.sql.erb
+++ b/spec/db/structure.sql.erb
@@ -4,7 +4,7 @@ CREATE TABLE `queue_test` (
   `title` varchar(255),
   `scheduled_at` bigint(20) NOT NULL DEFAULT '0',
   `enqueued_at` datetime NOT NULL
-) ENGINE=QUEUE;
+) ENGINE=<%= engine %>;
 
 DROP TABLE IF EXISTS `queue_test_without_scheduled_at`;
 
@@ -12,4 +12,4 @@ CREATE TABLE `queue_test_without_scheduled_at` (
   `job_id` varchar(255) NOT NULL,
   `title` varchar(255),
   `enqueued_at` datetime NOT NULL
-) ENGINE=QUEUE;
+) ENGINE=<%= engine %>;

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -3,7 +3,6 @@ require 'shinq'
 require 'shinq/client'
 
 describe "Integration", skip: ENV['TRAVIS'] do
-  let(:queue_table) { 'queue_test' }
 
   before do
     Shinq.configuration = {
@@ -13,28 +12,97 @@ describe "Integration", skip: ENV['TRAVIS'] do
   end
 
   after do
-    Shinq.connection.query("delete from #{queue_table}")
+    Shinq.clear_all_connections! # Return from owner mode
+    tables = Shinq.connection.query('show tables').flat_map(&:values)
+    tables.each do |table|
+      Shinq.connection.query("delete from #{table}")
+    end
+    Shinq.clear_all_connections!
   end
 
   describe "Shinq::Client.enqueue,dequeue" do
-    context "valid args" do
-      let(:args) { {title: 'foo'} }
+    before do
+      Timecop.freeze
+    end
+    after do
+      Timecop.return
+    end
+
+    context 'with scheduled_at on table' do
+      let(:queue_table) { 'queue_test' }
+      let(:job_id) { SecureRandom.uuid }
 
       before do
         Shinq::Client.enqueue(
           table_name: queue_table,
-          job_id: 'jobid',
-          args: args
+          job_id: job_id,
+          args: { title: :foo },
+          scheduled_at: scheduled_at
         )
-
-        @queue = Shinq::Client.dequeue(table_name: queue_table)
-        Shinq::Client.done
       end
 
-      it { expect(@queue[:title]).to eq args[:title] }
+      context 'when scheduled_at is not specified' do
+        let(:scheduled_at) { nil }
+
+        it 'can dequeue immediately' do
+          expect(Shinq::Client.dequeue(table_name: queue_table)[:job_id]).to eq job_id
+        end
+      end
+
+      context 'when scheduled_at is specified' do
+        let(:scheduled_at) { 1.minute.since }
+
+        it 'can not dequeue job immediately' do
+          expect(Shinq::Client.dequeue(table_name: queue_table)).to be nil
+        end
+
+        context 'when specified time elapsed' do
+          before do
+            Timecop.travel(1.second.since(scheduled_at))
+          end
+
+          it 'can dequeue job' do
+            expect(Shinq::Client.dequeue(table_name: queue_table)[:job_id]).to eq job_id
+          end
+        end
+      end
     end
 
-    context "invalid args" do
+    context 'without scheduled_at on table' do
+      let(:job_id) { SecureRandom.uuid }
+      let(:unschedulable_queue_table) { 'queue_test_without_scheduled_at' }
+
+      context 'when scheduled_at is not specified' do
+        before do
+          Shinq::Client.enqueue(
+            table_name: unschedulable_queue_table,
+            job_id: job_id,
+            args: { title: :foo },
+          )
+        end
+
+        it 'can dequeue job' do
+          expect(Shinq::Client.dequeue(table_name: unschedulable_queue_table)[:job_id]).to eq job_id
+        end
+      end
+
+      context 'when scheduled_at is specified' do
+        it 'cannot enqueue job' do
+          expect {
+            Shinq::Client.enqueue(
+              table_name: unschedulable_queue_table,
+              job_id: job_id,
+              args: { title: :foo },
+              scheduled_at: 1.minute.since,
+            )
+          }.to raise_error ArgumentError
+        end
+      end
+    end
+
+
+    context "with invalid args" do
+      let(:queue_table) { 'queue_test' }
       it {
         expect {
           Shinq::Client.enqueue(
@@ -48,6 +116,8 @@ describe "Integration", skip: ENV['TRAVIS'] do
   end
 
   describe "Shinq::Client.abort" do
+    let(:queue_table) { 'queue_test' }
+
     context "When client has a queue" do
       before do
         Shinq::Client.enqueue(
@@ -77,6 +147,8 @@ describe "Integration", skip: ENV['TRAVIS'] do
   end
 
   describe "Shinq::Client.queue_stats" do
+    let(:queue_table) { 'queue_test' }
+
     subject(:stats) {
       Shinq::Client.queue_stats(table_name: queue_table)
     }

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -58,7 +58,7 @@ describe "Integration", skip: ENV['TRAVIS'] do
 
         context 'when specified time elapsed' do
           before do
-            Timecop.travel(1.second.since(scheduled_at))
+            Timecop.travel(scheduled_at)
           end
 
           it 'can dequeue job' do

--- a/spec/shinq/cli_spec.rb
+++ b/spec/shinq/cli_spec.rb
@@ -2,6 +2,10 @@ require 'spec_helper'
 require 'shinq/cli'
 
 describe Shinq::CLI do
+  after do
+    Shinq.clear_all_connections!
+  end
+
   describe '.new' do
     context 'when there are require statement' do
       it 'requires and run the code' do

--- a/spec/shinq/client_spec.rb
+++ b/spec/shinq/client_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+require 'shinq'
+require 'shinq/client'
+
+def client_class
+  Shinq::Client.dup
+end
+
+describe Shinq::Client do
+  before do
+    Shinq.configuration = {
+      default_db: :test,
+      db_config: load_database_config
+    }
+  end
+
+  after do
+    Shinq.clear_all_connections!
+  end
+
+  describe '.schedulable?' do
+    context 'when target table have scheduled_at' do
+      it { expect(client_class.schedulable?(table_name: :queue_test)).to be true }
+    end
+
+    context 'when target table does NOT have scheduled_at' do
+      it { expect(client_class.schedulable?(table_name: :queue_test_without_scheduled_at)).to be false }
+    end
+  end
+
+  describe '.column_names' do
+    it 'fetches column_names' do
+      expect(client_class.column_names(table_name: :queue_test)).to eq(['job_id', 'title', 'scheduled_at', 'enqueued_at'])
+    end
+  end
+
+  describe 'fetch_column_names' do
+    it 'fetches column_names' do
+      expect(client_class.fetch_column_names(table_name: :queue_test)).to eq(['job_id', 'title', 'scheduled_at', 'enqueued_at'])
+    end
+  end
+end

--- a/spec/shinq/client_spec.rb
+++ b/spec/shinq/client_spec.rb
@@ -2,11 +2,15 @@ require 'spec_helper'
 require 'shinq'
 require 'shinq/client'
 
-def client_class
-  Shinq::Client.dup
-end
-
 describe Shinq::Client do
+  subject(:shinq_client) do
+    Shinq::Client.dup.tap do |client|
+      client.instance_variables.each do |variable|
+        client.remove_instance_variable(variable)
+      end
+    end
+  end
+
   before do
     Shinq.configuration = {
       default_db: :test,
@@ -20,23 +24,23 @@ describe Shinq::Client do
 
   describe '.schedulable?' do
     context 'when target table have scheduled_at' do
-      it { expect(client_class.schedulable?(table_name: :queue_test)).to be true }
+      it { expect(shinq_client.schedulable?(table_name: :queue_test)).to be true }
     end
 
     context 'when target table does NOT have scheduled_at' do
-      it { expect(client_class.schedulable?(table_name: :queue_test_without_scheduled_at)).to be false }
+      it { expect(shinq_client.schedulable?(table_name: :queue_test_without_scheduled_at)).to be false }
     end
   end
 
   describe '.column_names' do
     it 'fetches column_names' do
-      expect(client_class.column_names(table_name: :queue_test)).to eq(['job_id', 'title', 'scheduled_at', 'enqueued_at'])
+      expect(shinq_client.column_names(table_name: :queue_test)).to eq(['job_id', 'title', 'scheduled_at', 'enqueued_at'])
     end
   end
 
   describe 'fetch_column_names' do
     it 'fetches column_names' do
-      expect(client_class.fetch_column_names(table_name: :queue_test)).to eq(['job_id', 'title', 'scheduled_at', 'enqueued_at'])
+      expect(shinq_client.fetch_column_names(table_name: :queue_test)).to eq(['job_id', 'title', 'scheduled_at', 'enqueued_at'])
     end
   end
 end


### PR DESCRIPTION
@ryopeko 

# Summary

I would like to implement ActiveJob Delayed functionality through Q4M conditional subscription.

This PR contains commit which is to be merged by #14. If you can merge the PR, I can clean the changed files.

# Background

Sometimes we need Delayed functionality for ActiveJob in cases like

* Scheduling requirement like scheduled Push Notification
* Exponential backoff for unexpected system failure
* API limit on external services

Some ActiveJob adapters have implemented this and others have not.

Fortunately, Q4M has Conditional Subscription which is suited for Delayed or scheduled job.

# Implementation

* Add `scheduled_at` for scheduled date. (0 for default immediate job)
  * We use Unix time instead of datetime for a known issue on Q4M
* `ShinqAdapter#enqueue_at` for ActiveJob::QueueAdapter interface
* Maintain backward compatibility by fetching database column names
  * Alter table on Q4M could easily corrupt data with OWNER-mode connection.
  * Fetch database column before fork for performance issue.

# References
QueueAdapters
http://api.rubyonrails.org/classes/ActiveJob/QueueAdapters.html

implementation of Delayed Job by sidekiq
https://github.com/rails/rails/blob/4-2-stable/activejob/lib/active_job/queue_adapters/sidekiq_adapter.rb#L28-L35

Conditional Subscription
https://q4m.github.io/tutorial.html

conditional subscription fails against a column after than a DATETIME column (MySQL 5.6)
https://github.com/q4m/q4m/issues/9

ServerEngine Worker module interface
https://github.com/treasure-data/serverengine#worker-module

# Future work

After this PR is merged, I am going to implement a functionality to share the same queue between multiple Jobs. This can dramatically improves CPU and memory efficiency when there are many kind of workers and they are unevenly loaded.