### PR TITLE
Do not overwrite falsey value with defaults

### DIFF
--- a/lib/shinq/configuration.rb
+++ b/lib/shinq/configuration.rb
@@ -23,7 +23,9 @@ module Shinq
 
     def initialize(opts)
       %i(require worker_name db_config queue_db default_db process queue_timeout daemonize statistics lifecycle abort_on_error).each do |k|
-        send(:"#{k}=", opts[k] || DEFAULT[k])
+
+        value = opts.key?(k) ? opts[k] : DEFAULT[k]
+        send(:"#{k}=", value)
       end
     end
 


### PR DESCRIPTION
Shinq::Configuration did not handle default value properly.

When the passed option is falsey value (e.g. `nil` and `false`), default value is used instead of intentionally specified value.

For example, `--no-abort-on-error` option has been ignored since its implementation.

This patch will fix the bug.