### PR TITLE
Improve error handling on worker

### DIFF
--- a/lib/shinq/cli.rb
+++ b/lib/shinq/cli.rb
@@ -73,6 +73,10 @@ module Shinq
           opts[:abort_on_error] = v
         end
 
+        opt.on('--sleep-sec-on-error N', Integer, 'Allow worker to sleep(sec) after exception') do |v|
+          opts[:sleep_sec_on_error] = v
+        end
+
         opt.on('-v', '--version', 'Print version') do |v|
           puts "Shinq #{Shinq::VERSION}"
           exit(0)

--- a/lib/shinq/configuration.rb
+++ b/lib/shinq/configuration.rb
@@ -10,7 +10,7 @@ module Shinq
   #   You may need to set it +false+ for jobs which take very long time to proceed.
   #   You may also need to handle performing error manually then.
   class Configuration
-    attr_accessor :require, :worker_name, :db_config, :queue_db, :default_db, :process, :graceful_kill_timeout, :queue_timeout, :daemonize, :statistics, :lifecycle, :abort_on_error
+    attr_accessor :require, :worker_name, :db_config, :queue_db, :default_db, :process, :graceful_kill_timeout, :queue_timeout, :daemonize, :statistics, :lifecycle, :abort_on_error, :sleep_sec_on_error
 
     DEFAULT = {
       require: '.',
@@ -18,12 +18,12 @@ module Shinq
       graceful_kill_timeout: 600,
       queue_timeout: 1,
       daemonize: false,
-      abort_on_error: true
+      abort_on_error: true,
+      sleep_sec_on_error: 1,
     }
 
     def initialize(opts)
-      %i(require worker_name db_config queue_db default_db process queue_timeout daemonize statistics lifecycle abort_on_error).each do |k|
-
+      %i(require worker_name db_config queue_db default_db process queue_timeout daemonize statistics lifecycle abort_on_error sleep_sec_on_error).each do |k|
         value = opts.key?(k) ? opts[k] : DEFAULT[k]
         send(:"#{k}=", value)
       end


### PR DESCRIPTION
@ryopeko 

I have improved error handling on worker.
Following are the details.

* Wrap `Shinq::Client.dequeue` and `Shinq.configuration.abort_on_error` conditional block in `begin` ... `rescue` block
  * Most of MySQL-related errors (e.g. connection error) stem from `Shinq::Client.dequeue` where workers establish connection.
  * Also, there is no strong reason not to rescue errors when `--no-abort-on-error`
* Log error message instead of just raising exception to ServerEngine
  * Developers would like to see the error message in log file instead of STDOUT of daemons.
* Clean backtrace in error message when used with Rails.
  * By cleaning deep backtrace developers can smoothly trace the error cause.
* sleep when error occurs
  * When error occurs, instant queue_abort triggers rapid error bursts, which leads to DDoS to external services or high CPU consumption which deteriorate the other services running on the same machine.
  * Ideally above exceptions should be handled at each application level, but we need minimum failure tolerance functionality at library level. The proposed and currently successful strategy at our environment is holding the queue for some seconds (default: 1 second) at worker and then resume the original process. This strategy, which consumes clock time for both worker and queue, is effective enough whichever the cause is in the particular queue or the cause is in the system.
  * This does not trigger a severe performance issue by itself (i.e. workers are too busy sleeping to serve all the queue). Since only unexpected and unhandled exceptions are reached to this level, constant performance issue means we must fix the root cause immediately.