### PR TITLE
Update bundler before travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,6 @@ rvm:
 gemfile:
   - Gemfile
 before_install:
+  - gem update bundler
   - mysql -e "create database IF NOT EXISTS shinq_test;" -uroot
 script: bundle exec rspec


### PR DESCRIPTION
@ryopeko 

Bundler on used on travis have a bug and it leads to CI failures with some Ruby versions on #16 and #17.
I fixed this by updating bundler before install.

Details: https://github.com/bundler/bundler/issues/3558