### PR TITLE
Update dependencies on bundler and mysql2 to the latest

### DIFF
--- a/shinq.gemspec
+++ b/shinq.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.7"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "tapp"

--- a/shinq.gemspec
+++ b/shinq.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "simplecov"
   spec.add_development_dependency "timecop"
 
-  spec.add_dependency "mysql2", ">= 0.3.16", "< 0.5"
+  spec.add_dependency "mysql2", ">= 0.3.16", "< 0.6"
   spec.add_dependency "sql-maker", "~> 0.0.4"
   spec.add_dependency "activesupport", "~> 4.2.0"
   spec.add_dependency "activejob", "~> 4.2.0"


### PR DESCRIPTION
@ryopeko 

I have updated the following 2 dependencies to use the latest version.

* Bundler
  * Bundler 2 has been stable and we want to use them.
  * I think there are little reason to lock the version.
* Mysql2
  * The latest release version is 0.5.3, which was released on November 2019
  * https://github.com/brianmario/mysql2/releases/tag/0.5.3