### PR TITLE
Reorganize ruby versions for travis maintainability

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,11 @@ sudo: false
 cache: bundler
 rvm:
   - 2.1
-  - 2.2.0
-  - 2.2.1
-  - 2.2.2
-  - 2.2.7
-  - 2.3.4
-  - 2.4.1
+  - 2.2
+  - 2.3
+  - 2.4
+  - 2.6
+  - 2.7
 gemfile:
   - Gemfile
 before_install:


### PR DESCRIPTION
@ryopeko 

I have reorganized the ruby versions in travis

* Avoid specifying patch version to decrease the number of updates
* Add ruby 2.6 and 2.7