### PR TITLE
Run all the test in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  workflow_dispatch:  
 
 jobs:
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,11 @@ jobs:
       fail-fast: true
       matrix:
         ruby: [2.4, 2.5, 2.6, 2.7]
+    services:
+      mysql:
+        image: iwata/centos6-mysql56-q4m-hs
+        ports:
+          - 3306:3306
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,4 +37,4 @@ jobs:
     - name: Install dependencies
       run: bundle install
     - name: Run tests
-      run: bundle exec rake
+      run: bundle exec rspec

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+# This workflow will download a prebuilt Ruby version, install dependencies and run tests with Rake
+# For more information see: https://github.com/marketplace/actions/setup-ruby-jruby-and-truffleruby
+
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+    
+    strategy:
+      max-parallel: 1
+      fail-fast: true
+      matrix:
+        ruby: [2.4, 2.5, 2.6, 2.7]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby
+    # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
+    # change this to (see https://github.com/ruby/setup-ruby#versioning):
+    # uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
+      with:
+        bundler-cache: true
+        ruby-version: ${{ matrix.ruby }}
+    - name: Install dependencies
+      run: bundle install
+    - name: Run tests
+      run: bundle exec rake

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,13 +5,15 @@
 # This workflow will download a prebuilt Ruby version, install dependencies and run tests with Rake
 # For more information see: https://github.com/marketplace/actions/setup-ruby-jruby-and-truffleruby
 
-name: CI
+name: test
 
 on:
   push:
-    branches: [ master ]
+    branches:
+      - master
   pull_request:
-    branches: [ master ]
+    branches:
+      - master
   workflow_dispatch:  
 
 jobs:
@@ -20,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     
     strategy:
-      max-parallel: 1
+      max-parallel: 4
       fail-fast: true
       matrix:
         ruby: [2.4, 2.5, 2.6, 2.7]

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Shinq
 [![Build Status](https://travis-ci.org/ryopeko/shinq.svg)](https://travis-ci.org/ryopeko/shinq)
+[![CI](https://github.com/ryopeko/shinq/workflows/test/badge.svg?event=push)](https://github.com/ryopeko/shinq/actions?query=workflow%3Atest+event%3Apush)
 
 Worker and enqueuer for Q4M using the interface of ActiveJob.
 

--- a/spec/config/database.yml
+++ b/spec/config/database.yml
@@ -1,5 +1,6 @@
 test:
   encoding: utf8
   username: root
-  host: localhost
+  host: 127.0.0.1
+  port: 3306
   database: shinq_test

--- a/spec/db/structure.sql.erb
+++ b/spec/db/structure.sql.erb
@@ -1,3 +1,6 @@
+CREATE DATABASE IF NOT EXISTS shinq_test;
+USE shinq_test;
+
 DROP TABLE IF EXISTS `queue_test`;
 CREATE TABLE `queue_test` (
   `job_id` varchar(255) NOT NULL,


### PR DESCRIPTION
@ryopeko 

Since Travis build is continuously failing, I have setup codes to run the test in GitHub Actions.
Following are the specific improvements.

* Using containerized MySQL with Q4M image, now all the tests are executed in CI.
* Reduces files to maintain by including `CREATE DATABASE` statement in sql for tests.
* Tests on GitHub Actions is faster.

You can see samples here.
https://github.com/aeroastro/shinq/actions

If we can omit Travis CI, I will remove the Travis-related settings afterwards.