### PR TITLE
Support MySQL 8.0

### DIFF
--- a/lib/shinq/client.rb
+++ b/lib/shinq/client.rb
@@ -69,7 +69,7 @@ module Shinq
       @column_names_by_table_name[table_name.to_sym] ||= begin
         quoted = SQL::Maker::Quoting.quote(table_name)
         column = Shinq.connection.query(<<-EOS).map { |record| record['column_name'] }
-select column_name from information_schema.columns where table_schema = database() and table_name = #{quoted}
+select column_name as column_name from information_schema.columns where table_schema = database() and table_name = #{quoted}
         EOS
       end
     end


### PR DESCRIPTION
Since information_schema.columns is a database VIEW
with a `COLUMN_NAME` column, we need to explicitly
designate column in SQL.

https://dev.mysql.com/blog-archive/mysql-8-0-improvements-to-information_schema/

This change does not affect MySQL 5.7 and below.