### PR TITLE
Allow Rails 6.0

### DIFF
--- a/shinq.gemspec
+++ b/shinq.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "mysql2", ">= 0.3.16", "< 0.6"
   spec.add_dependency "sql-maker", "~> 0.0.4"
-  spec.add_dependency "activesupport", ">= 4.2.0", "< 6"
-  spec.add_dependency "activejob", ">= 4.2.0", "< 6"
+  spec.add_dependency "activesupport", ">= 4.2.0", "< 6.1"
+  spec.add_dependency "activejob", ">= 4.2.0", "< 6.1"
   spec.add_dependency 'serverengine', '~> 1.5.9'
 end


### PR DESCRIPTION
Hi
I would like to use shinq with Rails 6.0.

In my local environment, by just fixing gemspec, shinq seems to work with Rails 6.0.