### PR TITLE
Widen gem dependencies for improved update and reduced maintenance cost

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
         #
         # We test only the oldest and latest Ruby versions for each Rails version.
         gemfile: [gemfiles/rails_5.gemfile]
-        ruby: ['2.2', '2.6']
+        ruby: ['2.3', '2.6']
         include:
           - gemfile: gemfiles/rails_6.0.gemfile
             ruby: '2.5'

--- a/shinq.gemspec
+++ b/shinq.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rake"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "tapp"
   spec.add_development_dependency "rspec"
@@ -25,9 +25,10 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "timecop"
   spec.add_development_dependency "appraisal"
 
-  spec.add_dependency "mysql2", ">= 0.3.16", "< 0.6"
-  spec.add_dependency "sql-maker", "~> 0.0.4"
+  spec.add_dependency "mysql2", ">= 0.3.16", "< 1"
+  spec.add_dependency "sql-maker", ">= 0.0.4", "< 2"
+  spec.add_dependency 'serverengine', ">= 1.5.9", "< 3"
+
   spec.add_dependency "activesupport", ">= 4.2.0", "< 7.1"
   spec.add_dependency "activejob", ">= 4.2.0", "< 7.1"
-  spec.add_dependency 'serverengine', '~> 1.5.9'
 end

--- a/shinq.gemspec
+++ b/shinq.gemspec
@@ -16,6 +16,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
+  spec.required_ruby_version = ">= 2.3"
+
   spec.add_development_dependency "rake"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "tapp"


### PR DESCRIPTION
## Summary

As a developer of Shinq,
In order to get updated with the latest gems,
and to decrease the maintenance cost of Shinq,
I have largely widened the dependencies of this gem.


Regarding `mysql2`, `sql-maker` and `serverengine`,
because of their highly-maintained backward compatibilities,
we only have to specify the major versions.

Regarding activesupport and activejob,
because of their fastly-updated Rails features,
we keep specifying minor versions as before.
(Appraisal can take care of this update to be less burdened.)


Also, as a user of Shinq, widened dependencies can
improve gem update lifecycle of products using Shinq.

## Local Checking

In my local environment, both enqueueing from Rails app
and dequeueing from Shinq worker have worked as before
with the following latest gems.

* mysql2: 0.5.5
* sql-maker: 1.0.0
* serverengine: 2.3.1

Also, all the appraisal tests have passed in my local Mac.
I believe the CI on GitHub Actions will also pass.

Although the above tests do not check production readiness
like load test against heavy traffic, I think this can (or should)
be achieved out of the scope of maintenance of Shinq.