### PR TITLE
Support Trilogy

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,25 +18,17 @@ on:
 
 jobs:
   test:
-
     runs-on: ubuntu-latest
-    
     strategy:
       max-parallel: 4
       fail-fast: true
       matrix:
-        # In order to effectively specify Rails and Ruby versions simultaneously,
-        # we specify every tuple of versions in `include` section
-        # except for the tuples with a particular Rails version.
-        #
-        # The objective of the exception is to satisfy the
-        # constraint that a matrix cannot be empty.
-        #
         # We test only the oldest and latest Ruby versions for each Rails version.
-        gemfile: [gemfiles/rails_5.gemfile]
-        ruby: ['2.3', '2.6']
-        adapter: ['trilogy', 'mysql2']
-        include:
+        ruby_gemfile:
+          - gemfile: gemfiles/rails_5.gemfile
+            ruby: '2.3'
+          - gemfile: gemfiles/rails_5.gemfile
+            ruby: '2.6'
           - gemfile: gemfiles/rails_6.0.gemfile
             ruby: '2.5'
           - gemfile: gemfiles/rails_6.0.gemfile
@@ -49,9 +41,11 @@ jobs:
             ruby: '2.7'
           - gemfile: gemfiles/rails_7.0.gemfile
             ruby: '3.2'
-
+        adapter:
+          - trilogy
+          - mysql2
     env:
-      BUNDLE_GEMFILE: ${{ matrix.gemfile }}
+      BUNDLE_GEMFILE: ${{ matrix.ruby_gemfile.gemfile }}
     services:
       mysql:
         image: iwata/centos6-mysql56-q4m-hs
@@ -66,7 +60,7 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         bundler-cache: true
-        ruby-version: ${{ matrix.ruby }}
+        ruby-version: ${{ matrix.ruby_gemfile.ruby }}
     - name: Install dependencies
       run: bundle install
     - name: Run tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,6 +35,7 @@ jobs:
         # We test only the oldest and latest Ruby versions for each Rails version.
         gemfile: [gemfiles/rails_5.gemfile]
         ruby: ['2.3', '2.6']
+        adapter: ['trilogy', 'mysql2']
         include:
           - gemfile: gemfiles/rails_6.0.gemfile
             ruby: '2.5'
@@ -69,4 +70,6 @@ jobs:
     - name: Install dependencies
       run: bundle install
     - name: Run tests
+      env:
+        SHINQ_TEST_ADAPTER: ${{ matrix.adapter }}
       run: bundle exec rspec

--- a/README.md
+++ b/README.md
@@ -6,9 +6,10 @@ Worker and enqueuer for Q4M using the interface of ActiveJob.
 
 ## Installation
 
-Add this line to your application's Gemfile:
+Add these lines to your application's Gemfile:
 
 ```ruby
+gem 'mysql2' # or gem 'trilogy'
 gem 'shinq'
 ```
 
@@ -18,7 +19,7 @@ And then execute:
 
 Or install it yourself as:
 
-    $ gem install shinq
+    $ gem install mysql2 && gem install shinq
 
 [Install Q4M](http://q4m.github.io/install.html)
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ And then execute:
 
 Or install it yourself as:
 
-    $ gem install mysql2 && gem install shinq
+    $ gem install mysql2 shinq
 
 [Install Q4M](http://q4m.github.io/install.html)
 

--- a/lib/shinq.rb
+++ b/lib/shinq.rb
@@ -29,7 +29,7 @@ module Shinq
       case db_config[:adapter]
       when 'trilogy'
         require 'trilogy'
-        Trilogy.new(db_config)
+        Trilogy.new(db_config.dup)
       when 'mysql2', nil # for backward compatibility, we use mysql2 when adapter is not specified
         require 'mysql2'
         Mysql2::Client.new(db_config.merge(as: :array))

--- a/lib/shinq.rb
+++ b/lib/shinq.rb
@@ -24,7 +24,7 @@ module Shinq
 
   def self.setup_db_connection(db_name)
     raise Shinq::ConfigurationError unless self.configuration.db_defined?(db_name)
-    @connections[db_name.to_sym] = Mysql2::Client.new(self.configuration.db_config[db_name])
+    @connections[db_name.to_sym] = Mysql2::Client.new(self.configuration.db_config[db_name].merge(as: :array))
   end
 
   def self.connection(db_name: self.default_db)

--- a/lib/shinq.rb
+++ b/lib/shinq.rb
@@ -23,7 +23,7 @@ module Shinq
   end
 
   def self.setup_db_connection(db_name)
-    raise Shinq::ConfigurationError unless self.configuration.db_defined?(db_name)
+    raise Shinq::ConfigurationError, "#{db_name.inspect} is not defined in configuration" unless self.configuration.db_defined?(db_name)
     @connections[db_name.to_sym] = Mysql2::Client.new(self.configuration.db_config[db_name].merge(as: :array))
   end
 

--- a/lib/shinq.rb
+++ b/lib/shinq.rb
@@ -1,4 +1,3 @@
-require 'mysql2'
 require 'shinq/client'
 require 'shinq/configuration'
 
@@ -24,7 +23,19 @@ module Shinq
 
   def self.setup_db_connection(db_name)
     raise Shinq::ConfigurationError, "#{db_name.inspect} is not defined in configuration" unless self.configuration.db_defined?(db_name)
-    @connections[db_name.to_sym] = Mysql2::Client.new(self.configuration.db_config[db_name].merge(as: :array))
+
+    db_config = self.configuration.db_config[db_name]
+    @connections[db_name.to_sym] =
+      case db_config[:adapter]
+      when 'trilogy'
+        require 'trilogy'
+        Trilogy.new(db_config)
+      when 'mysql2', nil # for backward compatibility, we use mysql2 when adapter is not specified
+        require 'mysql2'
+        Mysql2::Client.new(db_config.merge(as: :array))
+      else
+        raise "Unsupported adapter: #{db_config[:adapter]}. Only trilogy and mysql2 are supported."
+      end
   end
 
   def self.connection(db_name: self.default_db)

--- a/shinq.gemspec
+++ b/shinq.gemspec
@@ -26,8 +26,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "simplecov"
   spec.add_development_dependency "timecop"
   spec.add_development_dependency "appraisal"
+  spec.add_development_dependency "trilogy"
+  spec.add_development_dependency "mysql2"
 
-  spec.add_dependency "mysql2", ">= 0.3.16", "< 1"
   spec.add_dependency "sql-maker", ">= 0.0.4", "< 2"
   spec.add_dependency 'serverengine', ">= 1.5.9", "< 3"
 

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -14,7 +14,7 @@ describe "Integration" do
 
   after do
     Shinq.clear_all_connections! # Return from owner mode
-    tables = Shinq.connection.query('show tables').flat_map(&:values)
+    tables = Shinq.connection.query('show tables').to_a.flatten
     tables.each do |table|
       Shinq.connection.query("delete from #{table}")
     end
@@ -127,12 +127,12 @@ describe "Integration" do
           args: {title: 'foo'}
         )
 
-        @queue_count = Shinq.connection.query("select count(*) as c from #{queue_table}").first['c']
+        @queue_count = Shinq.connection.query("select count(*) as c from #{queue_table}").first.first
 
         Shinq::Client.dequeue(table_name: queue_table)
         Shinq::Client.abort
 
-        @after_queue_count = Shinq.connection.query("select count(*) as c from #{queue_table}").first['c']
+        @after_queue_count = Shinq.connection.query("select count(*) as c from #{queue_table}").first.first
       end
 
       it { expect(@after_queue_count).to be @queue_count }

--- a/spec/shinq/client_spec.rb
+++ b/spec/shinq/client_spec.rb
@@ -34,13 +34,13 @@ describe Shinq::Client do
 
   describe '.column_names' do
     it 'fetches column_names' do
-      expect(shinq_client.column_names(table_name: :queue_test)).to eq(['job_id', 'title', 'scheduled_at', 'enqueued_at'])
+      expect(shinq_client.column_names(table_name: :queue_test).sort).to eq(['job_id', 'title', 'scheduled_at', 'enqueued_at'].sort)
     end
   end
 
   describe 'fetch_column_names' do
     it 'fetches column_names' do
-      expect(shinq_client.fetch_column_names(table_name: :queue_test)).to eq(['job_id', 'title', 'scheduled_at', 'enqueued_at'])
+      expect(shinq_client.fetch_column_names(table_name: :queue_test).sort).to eq(['job_id', 'title', 'scheduled_at', 'enqueued_at'].sort)
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,8 +11,8 @@ require 'active_support/core_ext/numeric/time'
 require 'mysql2'
 require 'timecop'
 
-def load_database_config
-  db_config = YAML.load_file(File.expand_path('./config/database.yml', __dir__)).deep_symbolize_keys
+def load_database_config(adapter: ENV.fetch('SHINQ_TEST_ADAPTER', 'trilogy'))
+  YAML.load_file(File.expand_path('./config/database.yml', __dir__)).deep_symbolize_keys.deep_merge(test: { adapter: adapter })
 end
 
 SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new(


### PR DESCRIPTION
[Trilogy](https://github.com/trilogy-libraries/trilogy) is a newly introduced client library for MySQL.
Ruby on Rails 7.1 introduced [TrilogyAdapter](https://guides.rubyonrails.org/7_1_release_notes.html#introduce-adapter-for-trilogy), a new MySQL adapter for ActiveRecord.

I implemented Trilogy support for Shinq.
By this PR, Shinq supports both Trilogy and Mysql2.

The following are the main changes:

* Respect `adapter` in the database.yml to allow users to switch between Mysql2 and Trilogy based on their configurations
  * If `adapter` is not specified, mysql2 is used
* Modify test.yml to test both Mysql2 and Trilogy
* Internally fetch data from MySQL as `Array`, not `Hash` to give compatibility between Mysql2 and Trilogy
  * Mysql2 and Trilogy behave almost identically when we use Mysql2 with the `as: :array` option, so by this change, we can use the same code for Mysql2 and Trilogy